### PR TITLE
Including error condition for evluate api

### DIFF
--- a/backend/controllers/controller.js
+++ b/backend/controllers/controller.js
@@ -15,14 +15,35 @@ exports.evaluate = (req, res) => {
     );
 
     expression.save(function (err) {
-        if (err) {
+		var x = "";
+		var er = "";
+		var error = "";
+        if (err) { 
             return next(err);
         }
 
         let data = {"soln": "", "status": "Success"};
-        let x = calc.evaluate((req.body.exp)).toString();
-        data['soln'] = x;
-        res.send(data);
+		try{
+			let x = calc.evaluate((req.body.exp)).toString();
+		}
+		catch(err) {
+			er = err.toString();
+			//var err = " ";
+			if(er.indexOf(" Parenthesis ") != -1) {
+				error = "Make sure paranthesis is balanced";
+			} else if(er.includes("Value expected") != -1) {
+				error = "Number missing after operator";
+				}
+		}
+		if(error) {
+			console.log(error);
+			data['soln'] = "error";
+			data['status'] = "Failed with Error" + error
+			res.send(data);
+		}  else {
+			data['soln'] = x;
+			res.send(data);
+		}
     })
 
 


### PR DESCRIPTION
This pull request is raised, regarding display of errors in case of invalid expression.
![image](https://user-images.githubusercontent.com/10029007/66238368-56690f80-e6ac-11e9-9add-670b9faf62d7.png)


This image shows the error condition as tested via RESTer